### PR TITLE
Fix previous post getting first post in database table.

### DIFF
--- a/Repositories/Eloquent/EloquentPostRepository.php
+++ b/Repositories/Eloquent/EloquentPostRepository.php
@@ -91,7 +91,7 @@ class EloquentPostRepository extends EloquentBaseRepository implements PostRepos
     public function getPreviousOf($post)
     {
         return $this->model->where('created_at', '<', $post->created_at)
-            ->whereStatus(Status::PUBLISHED)->first();
+            ->whereStatus(Status::PUBLISHED)->orderBy('created_at', 'desc')->first();
     }
 
     /**


### PR DESCRIPTION
Instead of getting the previous post, the repository was returning the very first post in the database table.

Signed-off-by: Micheal Mand <micheal@kmdwebdesigns.com>