### PR TITLE
Added calls to old() for the post content field

### DIFF
--- a/Resources/views/admin/posts/partials/create-fields.blade.php
+++ b/Resources/views/admin/posts/partials/create-fields.blade.php
@@ -10,5 +10,7 @@
        {!! $errors->first("$lang.slug", '<span class="help-block">:message</span>') !!}
     </div>
 
-    <textarea class="ckeditor" name="{{$lang}}[content]" rows="10" cols="80"></textarea>
+    <textarea class="ckeditor" name="{{$lang}}[content]" rows="10" cols="80">
+        {!! old("{$lang}.content") !!}
+    </textarea>
 </div>

--- a/Resources/views/admin/posts/partials/edit-fields.blade.php
+++ b/Resources/views/admin/posts/partials/edit-fields.blade.php
@@ -14,6 +14,6 @@
 
     <?php $oldContent = isset($post->translate($lang)->content) ? $post->translate($lang)->content : ''; ?>
     <textarea class="ckeditor" name="{{$lang}}[content]" rows="10" cols="80">
-    {!! $oldContent !!}
+    {!! old("{$lang}.content", $oldContent) !!}
     </textarea>
 </div>


### PR DESCRIPTION
When trying to create a new post or edit one all changes made to the content field were lost if the validation failed