### PR TITLE
Update widgets

### DIFF
--- a/Config/settings.php
+++ b/Config/settings.php
@@ -11,4 +11,9 @@ return [
         'view'         => 'text',
         'translatable' => true,
     ],
+    'widget-posts-amount' => [
+        'description' => 'blog::settings.widget-posts-amount',
+        'view' => 'text',
+        'translatable' => true,
+    ],
 ];

--- a/Resources/lang/en/settings.php
+++ b/Resources/lang/en/settings.php
@@ -3,4 +3,5 @@
 return [
     'posts-per-page' => 'Posts per page',
     'latest-posts-amount' => 'Amount of latest posts',
+    'widget-posts-amount' => 'Amount of latest posts to show on the dashboard widget',
 ];

--- a/Resources/views/admin/widgets/latest-posts.blade.php
+++ b/Resources/views/admin/widgets/latest-posts.blade.php
@@ -7,16 +7,14 @@
             <tbody><tr>
                 <th style="width: 10px">#</th>
                 <th>{{ trans('blog::post.table.title') }}</th>
-                <th>{{ trans('blog::post.table.slug') }}</th>
+                <th>{{ trans('core::core.table.created at') }}</th>
             </tr>
             <?php if (isset($posts)): ?>
                 <?php foreach ($posts as $post): ?>
                     <tr>
                         <td>{{ $post->id }}</td>
                         <td>{{ $post->title }}</td>
-                        <td>
-                            {{ $post->slug }}
-                        </td>
+                        <td>{{ $post->created_at }}</td>
                     </tr>
                 <?php endforeach; ?>
             <?php endif; ?>

--- a/Widgets/LatestPostsWidget.php
+++ b/Widgets/LatestPostsWidget.php
@@ -57,7 +57,7 @@ class LatestPostsWidget extends BaseWidget
      */
     protected function data()
     {
-        $limit = $this->setting->get('blog::latest-posts-amount', locale(), 5);
+        $limit = $this->setting->get('blog::widget-posts-amount', locale(), 5);
 
         return ['posts' => $this->post->latest($limit)];
     }


### PR DESCRIPTION
This PR is probably highly opinionated, but based on feedback from multiple clients using the Blog module they are common frustrations.

- Add another option to control the number of latest posts shown on the dashboard
    - If the user wishes to show many latest posts on their site (10 or more, for example), the widget grows uncontrollably big; especially if the titles are fairly long - they end up wrapping and making the widget even longer.

- Replace post slug with created_at on the widget
    - Most non-techie users don't care what the slug is, but a quick glance to see when the last few articles were posted would be more helpful.