### PR TITLE
Updated Post Scopes

### DIFF
--- a/Entities/Post.php
+++ b/Entities/Post.php
@@ -60,31 +60,28 @@ class Post extends Model
     /**
      * Check if the post is pending review
      * @param Builder $query
-     * @return bool
      */
     public function scopePending(Builder $query)
     {
-        return (bool) $query->whereStatus(1);
+        return $query->whereStatus(1);
     }
 
     /**
      * Check if the post is published
      * @param Builder $query
-     * @return bool
      */
     public function scopePublished(Builder $query)
     {
-        return (bool) $query->whereStatus(2);
+        return $query->whereStatus(2);
     }
 
     /**
      * Check if the post is unpublish
      * @param Builder $query
-     * @return bool
      */
     public function scopeUnpublished(Builder $query)
     {
-        return (bool) $query->whereStatus(3);
+        return $query->whereStatus(3);
     }
 
     /**

--- a/Entities/Post.php
+++ b/Entities/Post.php
@@ -50,16 +50,17 @@ class Post extends Model
     /**
      * Check if the post is in draft
      * @param Builder $query
-     * @return bool
+     * @return Builder
      */
     public function scopeDraft(Builder $query)
     {
-        return (bool) $query->whereStatus(0);
+        return $query->whereStatus(0);
     }
 
     /**
      * Check if the post is pending review
      * @param Builder $query
+     * @return Builder
      */
     public function scopePending(Builder $query)
     {
@@ -69,6 +70,7 @@ class Post extends Model
     /**
      * Check if the post is published
      * @param Builder $query
+     * @return Builder
      */
     public function scopePublished(Builder $query)
     {
@@ -78,6 +80,7 @@ class Post extends Model
     /**
      * Check if the post is unpublish
      * @param Builder $query
+     * @return Builder
      */
     public function scopeUnpublished(Builder $query)
     {


### PR DESCRIPTION
As per the [docs](https://laravel.com/docs/5.1/eloquent#query-scopes) the Post entity scopes should return the query builder rather than returning a bool.