### PR TITLE
Base Menu Heading Hiding Logic To Use Subitem Count

### DIFF
--- a/Sidebar/SidebarExtender.php
+++ b/Sidebar/SidebarExtender.php
@@ -64,9 +64,12 @@ class SidebarExtender implements \Maatwebsite\Sidebar\SidebarExtender
                         $this->auth->hasAccess('blog.categories.index')
                     );
                 });
-                $item->authorize(
-                    $this->auth->hasAccess('blog.tags.index') || $this->auth->hasAccess('blog.posts.index') || $this->auth->hasAccess('blog.categories.index')
-                );
+
+                $authorizedItemCount = $item->getItems()->filter(function (Item $item) {
+                    return $item->isAuthorized();
+                })->count();
+
+                $item->authorize($authorizedItemCount > 0);
             });
         });
 


### PR DESCRIPTION
Changed the logic that decides whether the menu heading should be hidden to check the number of sub items rather than doing permission checks.